### PR TITLE
Update Ethereum Label and Split Node Type Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ grunt all
 ##Run
 
 ```bash
-npm start
+# For PoS Amoy
+NETWORK_NAME="PoS Amoy" npm start
+
+# For PoS Mainnet
+NETWORK_NAME="PoS Mainnet" npm start
 ```
 
 see the interface at http://localhost:3000

--- a/lib/express.js
+++ b/lib/express.js
@@ -8,11 +8,14 @@ app.set('views', path.join(__dirname, (process.env.LITE === 'true' ? '../src-lit
 app.set('view engine', 'jade');
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
-app.use(express.static(path.join(__dirname, (process.env.LITE === 'true' ? '../dist-lite' : '../dist'))));
+
+app.locals.networkName = process.env.NETWORK_NAME || "PoS Mainnet";
 
 app.get('/', function(req, res) {
   res.render('index');
 });
+app.use(express.static(path.join(__dirname, (process.env.LITE === 'true' ? '../dist-lite' : '../dist'))));
+
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/src/views/index.jade
+++ b/src/views/index.jade
@@ -163,7 +163,7 @@ block content
             div.active-nodes.text-warning
               i.icon-warning-o
               span.small-title ATTENTION!
-              span.small-value This page does not represent the entire state of the PoS mainnet/ Amoy network - listing a node on this page is a voluntary process.
+              span.small-value This page does not represent the entire state of the #{networkName} - listing a node on this page is a voluntary process.
           //- div.col-xs-12.stat-holder.box
           //-   div.active-nodes.text-danger
           //-     i.icon-hashrate

--- a/src/views/index.jade
+++ b/src/views/index.jade
@@ -163,7 +163,7 @@ block content
             div.active-nodes.text-warning
               i.icon-warning-o
               span.small-title ATTENTION!
-              span.small-value This page does not represent the entire state of the ethereum network - listing a node on this page is a voluntary process.
+              span.small-value This page does not represent the entire state of the PoS mainnet/ Amoy network - listing a node on this page is a voluntary process.
           //- div.col-xs-12.stat-holder.box
           //-   div.active-nodes.text-danger
           //-     i.icon-hashrate
@@ -182,8 +182,12 @@ block content
               i.icon-check-o(data-toggle="tooltip", data-placement="top", title="Pin nodes to display first", ng-click="orderTable(['-stats.block.number', 'stats.block.propagation'], false)")
             th.th-nodename
               i.icon-node(data-toggle="tooltip", data-placement="top", title="Node name", ng-click="orderTable(['info.name'], false)")
-            th.th-nodetype
-              i.icon-laptop(data-toggle="tooltip", data-placement="top", title="Node type", ng-click="orderTable(['info.node'], false)")
+            th.th-borversion
+              | Bor Version
+            th.th-arch
+              | Architecture
+            th.th-goversion
+              | Go Version
             th.th-latency
               i.icon-clock(data-toggle="tooltip", data-placement="top", title="Node latency", ng-click="orderTable(['stats.latency'], false)")
             th
@@ -220,7 +224,11 @@ block content
               a.small(href="https://github.com/ethereum/wiki/wiki/Network-Status#updating", target="_blank", data-toggle="tooltip", data-placement="top", data-html="true", data-original-title="Netstats client needs update.<br>Click this icon for instructions.", class="{{ node.info | nodeClientClass : currentApiVersion }}")
                 i.icon-warning-o
             td
-              div.small(ng-bind-html="node.info.node | nodeVersion")
+              span.small {{ node.info.node.split('/')[1] || '-' }}
+            td
+              span.small {{ node.info.node.split('/')[2] || '-' }}
+            td
+              span.small {{ node.info.node.split('/')[3] || '-' }}
             td(class="{{ node.readable.latencyClass }}")
               span.small {{ node.readable.latency }}
             td(class="{{ node.stats.mining | hashrateClass : node.stats.active }}", ng-bind-html="node.stats.hashrate | hashrateFilter : node.stats.mining")


### PR DESCRIPTION
1. Updated Ethereum Label to "PoS Mainnet / Amoy"
2. Split Node Type field to :
    - Bor Version
    - Architecture
    - Go Version

